### PR TITLE
Refactor/accept different instruments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,13 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-router-dom": "^6.10.0"
       },
       "devDependencies": {
         "@types/react": "^18.0.28",
         "@types/react-dom": "^18.0.11",
+        "@types/react-router-dom": "^5.3.3",
         "@vitejs/plugin-react": "^3.1.0",
         "typescript": "^4.9.3",
         "vite": "^4.2.0"
@@ -774,6 +776,20 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "node_modules/@remix-run/router": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.5.0.tgz",
+      "integrity": "sha512-bkUDCp8o1MvFO+qxkODcbhSqRa6P2GXgrGZVpt0dCXNW2HCSCqYI0ZoAqEOSAjRWmmlKcYgFvN4B4S+zo/f8kg==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@types/history": {
+      "version": "4.7.11",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
+      "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
+      "dev": true
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
@@ -798,6 +814,27 @@
       "dev": true,
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-router": {
+      "version": "5.1.20",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.20.tgz",
+      "integrity": "sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-router-dom": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
+      "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
+      "dev": true,
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router": "*"
       }
     },
     "node_modules/@types/scheduler": {
@@ -1232,6 +1269,36 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.10.0.tgz",
+      "integrity": "sha512-Nrg0BWpQqrC3ZFFkyewrflCud9dio9ME3ojHCF/WLsprJVzkq3q3UeEhMCAW1dobjeGbWgjNn/PVF6m46ANxXQ==",
+      "dependencies": {
+        "@remix-run/router": "1.5.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.10.0.tgz",
+      "integrity": "sha512-E5dfxRPuXKJqzwSe/qGcqdwa18QiWC6f3H3cWXM24qj4N0/beCIf/CWTipop2xm7mR0RCS99NnaqPNjHtrAzCg==",
+      "dependencies": {
+        "@remix-run/router": "1.5.0",
+        "react-router": "6.10.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/resolve": {
@@ -1878,6 +1945,17 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "@remix-run/router": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.5.0.tgz",
+      "integrity": "sha512-bkUDCp8o1MvFO+qxkODcbhSqRa6P2GXgrGZVpt0dCXNW2HCSCqYI0ZoAqEOSAjRWmmlKcYgFvN4B4S+zo/f8kg=="
+    },
+    "@types/history": {
+      "version": "4.7.11",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
+      "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
+      "dev": true
+    },
     "@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
@@ -1902,6 +1980,27 @@
       "dev": true,
       "requires": {
         "@types/react": "*"
+      }
+    },
+    "@types/react-router": {
+      "version": "5.1.20",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.20.tgz",
+      "integrity": "sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==",
+      "dev": true,
+      "requires": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*"
+      }
+    },
+    "@types/react-router-dom": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
+      "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
+      "dev": true,
+      "requires": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router": "*"
       }
     },
     "@types/scheduler": {
@@ -2200,6 +2299,23 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
       "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
       "dev": true
+    },
+    "react-router": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.10.0.tgz",
+      "integrity": "sha512-Nrg0BWpQqrC3ZFFkyewrflCud9dio9ME3ojHCF/WLsprJVzkq3q3UeEhMCAW1dobjeGbWgjNn/PVF6m46ANxXQ==",
+      "requires": {
+        "@remix-run/router": "1.5.0"
+      }
+    },
+    "react-router-dom": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.10.0.tgz",
+      "integrity": "sha512-E5dfxRPuXKJqzwSe/qGcqdwa18QiWC6f3H3cWXM24qj4N0/beCIf/CWTipop2xm7mR0RCS99NnaqPNjHtrAzCg==",
+      "requires": {
+        "@remix-run/router": "1.5.0",
+        "react-router": "6.10.0"
+      }
     },
     "resolve": {
       "version": "1.22.1",

--- a/package.json
+++ b/package.json
@@ -10,11 +10,13 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.10.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
+    "@types/react-router-dom": "^5.3.3",
     "@vitejs/plugin-react": "^3.1.0",
     "typescript": "^4.9.3",
     "vite": "^4.2.0"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,143 +1,16 @@
 import "./App.css"
-import { useState, useEffect } from "react"
-import { Button } from "./components/Button"
-import { TFrenchHornFingerings } from "./types"
-import { fingerings } from "./fingerings"
-import { musicNotes } from "./musicNotes"
-import { Instrument } from "./components/Instrument"
+import { Link } from "react-router-dom"
 
 function App() {
-  const [note, setNote] = useState("")
-  const [selected, setSelected] = useState<string[]>([])
-  const [displayText, setDisplayText] = useState("")
-
-  useEffect(() => {
-    askQuestion()
-  }, [])
-
-  function askQuestion() {
-    // this sets a random note on refresh
-    const letters = [
-      // some commented out to deal with fingerings, haven't decided whether to include them or not
-      "A",
-      // "A#",
-      "Ab",
-      "B",
-      // "B#",
-      "Bb",
-      "C",
-      // "C#",
-      // "Cb",
-      "D",
-      // "D#",
-      "Db",
-      "E",
-      // "E#",
-      "Eb",
-      "F",
-      // "F#",
-      // "Fb",
-      "G",
-      // "G#",
-      "Gb",
-    ]
-    const numbers = [4] // right now just 4, until fingerings update
-    const randomNum1 = Math.floor(Math.random() * letters.length)
-    const randomNum2 = Math.floor(Math.random() * numbers.length)
-    setNote(`${letters[randomNum1]}${numbers[randomNum2]}`)
-    setDisplayText("")
-    setSelected([])
-  }
-
-  function selectFinger(text: string) {
-    setSelected((prevState) => {
-      if (prevState.includes(text)) {
-        // this means the button was already in selected, so we need to "unselect" it
-        return unselectButton(prevState, text)
-      } else {
-        // the button was not selected, so we need to select it
-        return selectButton(prevState, text)
-      }
-    })
-  }
-
-  function checkAnswer() {
-    if (
-      fingerings.frenchHorn[
-        selected.join("") as keyof TFrenchHornFingerings
-      ].includes(note)
-    ) {
-      setDisplayText("Correct!")
-    } else {
-      setDisplayText("Try Again!")
-    }
-  }
-
-  function unselectButton(prevState: string[], text: string) {
-    return [...prevState.filter((button) => button !== text)]
-  }
-
-  function selectButton(prevState: string[], text: string) {
-    return [...prevState, text].sort(
-      (a, b) => (a.charCodeAt(0) > 65 ? -1 : parseInt(a) - parseInt(b)) // this sorting algorithm puts T first, then numbers in ascending order
-    )
-  }
-
   return (
     <div>
-      <Instrument name="French Horn" />
-      <h1 className="title">French Horn Fingerings</h1>
-      <p className="music-notation">
-        {musicNotes.trebleClefWithStaff +
-          musicNotes[note as keyof typeof musicNotes] +
-          musicNotes.staffEnd}
-      </p>
-      {/* <img src={`/${note}.png`} alt={note} /> */}
-      <div className="buttons">
-        <Button
-          text="T"
-          type="input"
-          tabIndex={1}
-          handleFingeringClick={selectFinger}
-          selected={selected}
-        />
-        <Button
-          text="1"
-          type="input"
-          tabIndex={2}
-          handleFingeringClick={selectFinger}
-          selected={selected}
-        />
-        <Button
-          text="2"
-          type="input"
-          tabIndex={3}
-          handleFingeringClick={selectFinger}
-          selected={selected}
-        />
-        <Button
-          text="3"
-          type="input"
-          tabIndex={4}
-          handleFingeringClick={selectFinger}
-          selected={selected}
-        />
-      </div>
-      <Button
-        text="Check Answer"
-        type="action"
-        tabIndex={5}
-        handleActionButtonClick={checkAnswer}
-        selected={selected}
-      />
-      <Button
-        text="Reset"
-        type="action"
-        tabIndex={6}
-        handleActionButtonClick={askQuestion}
-        selected={selected}
-      />
-      <div className="display">{displayText}</div>
+      <h1 className="title">Band Fingerings</h1>
+      <p className="subtitle">Learn fingerings for any band instrument</p>
+      <h2 className="section-heading">Select your instrument</h2>
+      <Link tabIndex={1} to={"/fhorn"}>
+        French Horn
+      </Link>
+      <p>Other instruments coming soon!</p>
     </div>
   )
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { Button } from "./components/Button"
 import { TFrenchHornFingerings } from "./types"
 import { fingerings } from "./fingerings"
 import { musicNotes } from "./musicNotes"
+import { Instrument } from "./components/Instrument"
 
 function App() {
   const [note, setNote] = useState("")
@@ -84,6 +85,7 @@ function App() {
 
   return (
     <div>
+      <Instrument name="French Horn" />
       <h1 className="title">French Horn Fingerings</h1>
       <p className="music-notation">
         {musicNotes.trebleClefWithStaff +

--- a/src/components/Instrument.tsx
+++ b/src/components/Instrument.tsx
@@ -1,5 +1,0 @@
-import { TInstrumentProps } from "../types"
-
-export function Instrument({ name }: TInstrumentProps) {
-  return <div>{name}</div>
-}

--- a/src/components/Instrument.tsx
+++ b/src/components/Instrument.tsx
@@ -1,0 +1,5 @@
+import { TInstrumentProps } from "../types"
+
+export function Instrument({ name }: TInstrumentProps) {
+  return <div>{name}</div>
+}

--- a/src/components/InstrumentPage.tsx
+++ b/src/components/InstrumentPage.tsx
@@ -1,0 +1,140 @@
+import { TInstrumentPageProps } from "../types"
+import { useState, useEffect } from "react"
+import { Button } from "./Button"
+import { TFrenchHornFingerings } from "../types"
+import { fingerings } from "../fingerings"
+import { musicNotes } from "../musicNotes"
+
+export function InstrumentPage({ name }: TInstrumentPageProps) {
+  const [note, setNote] = useState("")
+  const [selected, setSelected] = useState<string[]>([])
+  const [displayText, setDisplayText] = useState("")
+
+  useEffect(() => {
+    askQuestion()
+  }, [])
+
+  function askQuestion() {
+    // this sets a random note on refresh
+    const letters = [
+      // some commented out to deal with fingerings, haven't decided whether to include them or not
+      "A",
+      // "A#",
+      "Ab",
+      "B",
+      // "B#",
+      "Bb",
+      "C",
+      // "C#",
+      // "Cb",
+      "D",
+      // "D#",
+      "Db",
+      "E",
+      // "E#",
+      "Eb",
+      "F",
+      // "F#",
+      // "Fb",
+      "G",
+      // "G#",
+      "Gb",
+    ]
+    const numbers = [4] // right now just 4, until fingerings update
+    const randomNum1 = Math.floor(Math.random() * letters.length)
+    const randomNum2 = Math.floor(Math.random() * numbers.length)
+    setNote(`${letters[randomNum1]}${numbers[randomNum2]}`)
+    setDisplayText("")
+    setSelected([])
+  }
+
+  function selectFinger(text: string) {
+    setSelected((prevState) => {
+      if (prevState.includes(text)) {
+        // this means the button was already in selected, so we need to "unselect" it
+        return unselectButton(prevState, text)
+      } else {
+        // the button was not selected, so we need to select it
+        return selectButton(prevState, text)
+      }
+    })
+  }
+
+  function checkAnswer() {
+    if (
+      fingerings.frenchHorn[
+        selected.join("") as keyof TFrenchHornFingerings
+      ].includes(note)
+    ) {
+      setDisplayText("Correct!")
+    } else {
+      setDisplayText("Try Again!")
+    }
+  }
+
+  function unselectButton(prevState: string[], text: string) {
+    return [...prevState.filter((button) => button !== text)]
+  }
+
+  function selectButton(prevState: string[], text: string) {
+    return [...prevState, text].sort(
+      (a, b) => (a.charCodeAt(0) > 65 ? -1 : parseInt(a) - parseInt(b)) // this sorting algorithm puts T first, then numbers in ascending order
+    )
+  }
+  return (
+    <div>
+      <h1 className="title">French Horn Fingerings</h1>
+      <p className="music-notation">
+        {musicNotes.trebleClefWithStaff +
+          musicNotes[note as keyof typeof musicNotes] +
+          musicNotes.staffEnd}
+      </p>
+      {/* <img src={`/${note}.png`} alt={note} /> */}
+      <div className="buttons">
+        <Button
+          text="T"
+          type="input"
+          tabIndex={1}
+          handleFingeringClick={selectFinger}
+          selected={selected}
+        />
+        <Button
+          text="1"
+          type="input"
+          tabIndex={2}
+          handleFingeringClick={selectFinger}
+          selected={selected}
+        />
+        <Button
+          text="2"
+          type="input"
+          tabIndex={3}
+          handleFingeringClick={selectFinger}
+          selected={selected}
+        />
+        <Button
+          text="3"
+          type="input"
+          tabIndex={4}
+          handleFingeringClick={selectFinger}
+          selected={selected}
+        />
+      </div>
+      <Button
+        text="Check Answer"
+        type="action"
+        tabIndex={5}
+        handleActionButtonClick={checkAnswer}
+        selected={selected}
+      />
+      <Button
+        text="Reset"
+        type="action"
+        tabIndex={6}
+        handleActionButtonClick={askQuestion}
+        selected={selected}
+      />
+      <div className="display">{displayText}</div>
+    </div>
+  )
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import ReactDOM from "react-dom/client"
 import App from "./App"
 import { createBrowserRouter, RouterProvider } from "react-router-dom"
+import { InstrumentPage } from "./components/InstrumentPage"
 
 const router = createBrowserRouter([
   {
@@ -10,7 +11,7 @@ const router = createBrowserRouter([
   },
   {
     path: "/fhorn",
-    element: <div>hello french horns!</div>,
+    element: <InstrumentPage name="French Horn" />,
   },
 ])
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,21 @@
 import React from "react"
 import ReactDOM from "react-dom/client"
 import App from "./App"
+import { createBrowserRouter, RouterProvider } from "react-router-dom"
+
+const router = createBrowserRouter([
+  {
+    path: "/",
+    element: <App />,
+  },
+  {
+    path: "/fhorn",
+    element: <div>hello french horns!</div>,
+  },
+])
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <RouterProvider router={router} />
   </React.StrictMode>
 )

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,6 @@ export type TButtonProps = {
   selected: string[]
 }
 
-export type TInstrumentProps = {
+export type TInstrumentPageProps = {
   name: string
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,3 +29,7 @@ export type TButtonProps = {
   handleActionButtonClick?: () => void
   selected: string[]
 }
+
+export type TInstrumentProps = {
+  name: string
+}


### PR DESCRIPTION
This partially completes the refactor described in issue #3 : Now using [React Router](https://reactrouter.com/en/main/start/tutorial) there is a select page at the home route ("/"), which will be used to link to each instrument's specific page. All code from the previous app has been transferred over to the "/fhorn" using the Instrument Page component, which will need to be further refactored to actually be modular for each instrument, but now there is a little more of a mechanism to do that. 